### PR TITLE
Add openbazaar-go HTTP API link to nav

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,11 @@ weight = 4
 identifier = "api"
 name = "Commands & API"
 weight = 4
+[[menu.reference]]
+parent = "api"
+name = "openbazaar-go HTTP API (Postman)"
+url = "https://api.docs.openbazaar.org"
+weight = 50
 
 [[menu.reference]]
 identifier = "go_implementation"


### PR DESCRIPTION
Include a link to the openbazaar-go API reference. Unsure about the name of the link. I also haven't tested that this works properly, but this seems like it would.